### PR TITLE
fix(ci): bridge release-plz to Release binaries via workflow_dispatch

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -5,6 +5,15 @@ name: Release binaries
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag (e.g. v1.2.3)'
+        required: true
+        type: string
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.event.release.tag_name }}
 
 jobs:
   build:
@@ -32,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -81,7 +92,7 @@ jobs:
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
           files: artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +106,8 @@ jobs:
     steps:
       - name: Checkout Main Repo
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Checkout Homebrew Tap
         uses: actions/checkout@v6
@@ -107,7 +120,7 @@ jobs:
         id: version
         run: echo "version=${TAG_NAME#v}" >> $GITHUB_OUTPUT
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ env.RELEASE_TAG }}
 
       - name: Download Release Assets and Calculate Checksums
         run: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,6 +11,7 @@ jobs:
     if: ${{ github.repository_owner == 'GarthDB' }}
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -22,11 +23,29 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger binary builds
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASES_JSON: ${{ steps.release-plz.outputs.releases }}
+        run: |
+          set -euo pipefail
+          TAG=$(echo "$RELEASES_JSON" | jq -r '.[0].tag // empty')
+          if [ -z "$TAG" ]; then
+            TAG=$(echo "$RELEASES_JSON" | jq -r 'if .[0].version then "v" + (.[0].version | tostring) else empty end')
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not determine release tag from releases output"
+            exit 1
+          fi
+          gh workflow run release-binaries.yml -f "tag_name=$TAG"
 
   release-plz-pr:
     name: Release-plz PR

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -439,7 +439,7 @@ fn test_cli_version_flag() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("scripture-links"));
-    assert!(stdout.contains("1.2.1")); // Current version
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]
@@ -452,7 +452,7 @@ fn test_cli_version_short_flag() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("scripture-links"));
-    assert!(stdout.contains("1.2.1")); // Current version
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Releases created by release-plz with `GITHUB_TOKEN` do not trigger workflows that use `on: release`, so **Release binaries** never ran and Homebrew was not updated.

## Solution

- **release-binaries.yml**: add `workflow_dispatch` with `tag_name`, set `RELEASE_TAG` for both `release` and manual runs, check out the tag when building and when updating Homebrew.
- **release-plz.yml**: grant `actions: write`, capture release-plz outputs, and run `gh workflow run release-binaries.yml -f tag_name=...` when `releases_created` is true.

## Also

- CLI integration tests now assert version via `env!("CARGO_PKG_VERSION")` so they stay in sync with Cargo.toml.

## After merge

Manually dispatch **Release binaries** with `tag_name=v1.2.2` to backfill assets for the current release.

Made with [Cursor](https://cursor.com)